### PR TITLE
A much faster filterList() proc

### DIFF
--- a/code/world/world.dm
+++ b/code/world/world.dm
@@ -21,15 +21,21 @@ var/list/procObjects = list()
 /proc/remProcessingObject(var/obj/r)
 	procObjects -= r
 
-/proc/filterList(var/filter,var/list/inList,var/list/excludeExplicit)
-	for(var/a in inList)
-		var/aPos = inList.Find(a)
-		if(excludeExplicit)
-			if(excludeExplicit.Find(a))
-				inList.Cut(aPos,aPos+1)
-		if(!istype(a,filter))
-			inList.Cut(aPos,aPos+1)
-	. = inList
+
+/proc/filterList(var/filter, var/list/inList, var/list/explicitExcluded)
+	set background = 1
+	var/list/newList = list()
+	for(var/i = 1, i <= inList.len, i++)
+		var/j = inList[i]
+		if(explicitExcluded)
+			if(j in explicitExcluded)
+				continue
+		if(!istype(j, filter))
+			continue
+
+		newList += j
+	. = newList
+
 
 /proc/processObjects()
 	if(procObjects.len)


### PR DESCRIPTION
What it says on the tin, from my tests of brute forcing 10000 numbers (1-10000) the original filterList() takes 4.8 ticks, with mine taking 0.400009 ticks, a MASSIVE improvement.

These numbers will be slightly different considering the use of istype() in the proper build, but mine should still win out by a longshot.

Correctly excludes the excluded, correctly filters the filter.